### PR TITLE
Add null check to prevent RTE

### DIFF
--- a/src/gen/js/service.js.template
+++ b/src/gen/js/service.js.template
@@ -92,7 +92,7 @@ function formatParamsGroup(groups) {
 }
 
 function formatParam(param) {
-	if (param === undefined) return '';;
+	if (param === undefined || param === null) return '';;
 	else if (param instanceof Date) return param.toJSON();;
 	else return param.toString();;
 }

--- a/src/gen/js/service.ts.template
+++ b/src/gen/js/service.ts.template
@@ -97,7 +97,7 @@ function formatParamsGroup(groups: api.OperationParamGroups) {
 }
 
 function formatParam(param: any): string {
-	if (param === undefined) return '';;
+	if (param === undefined || param === null) return '';;
 	else if (param instanceof Date) return param.toJSON();;
 	else return param.toString();;
 }


### PR DESCRIPTION
* Prevents a runtime exception when calling `param.toString()` if it's null.