### PR TITLE
Fix support for Multi Collection Format

### DIFF
--- a/src/gen/js/genSpec.ts
+++ b/src/gen/js/genSpec.ts
@@ -22,7 +22,7 @@ function renderSpecView(spec: ApiSpec, options: ClientOptions): string {
     accepts: spec.accepts,
     securityDefinitions: spec.securityDefinitions
   }
-  const type = (options.language === 'ts') ?  ': api.OpenApiSpec' : ''
+  const type = (options.language === 'ts') ? ': api.OpenApiSpec' : ''
   return `${options.language === 'ts' ? '/// <reference path="../types.ts"/>': ''}
 // Auto-generated, edits will be overwritten
 const spec${type} = ${stringify(view)}${ST}

--- a/src/gen/js/genTypes.ts
+++ b/src/gen/js/genTypes.ts
@@ -27,7 +27,7 @@ function renderHeader() {
 function renderDefinitions(spec: ApiSpec, options: ClientOptions): string[] {
   const isTs = (options.language === 'ts')
   const defs = spec.definitions || {}
-  const typeLines = [`namespace api {`]
+  const typeLines = isTs ? [`namespace api {`] : undefined
   const docLines = []
   Object.keys(defs).forEach(name => {
     const def = defs[name]
@@ -36,9 +36,11 @@ function renderDefinitions(spec: ApiSpec, options: ClientOptions): string[] {
     }
     join(docLines, renderTypeDoc(name, def))
   })
-  join(typeLines, renderTsDefaultTypes())
-  typeLines.push('}')
-  return typeLines.concat(docLines)
+  if (isTs) {
+    join(typeLines, renderTsDefaultTypes())
+    typeLines.push('}')
+  }
+  return isTs ? typeLines.concat(docLines) : docLines
 }
 
 function renderTsType(name, def, options) {
@@ -139,7 +141,7 @@ export interface OperationSecurity {
 export interface OperationParamGroups {
   header?: {[key: string]: string}${ST}
   path?: {[key: string]: string|number|boolean}${ST}
-  query?: {[key: string]: string|number|boolean}${ST}
+  query?: {[key: string]: string|string[]|number|boolean}${ST}
   formData?: {[key: string]: string|number|boolean}${ST}
   body?: any${ST}
 }

--- a/src/gen/js/service.js.template
+++ b/src/gen/js/service.js.template
@@ -94,6 +94,7 @@ function formatParamsGroup(groups) {
 function formatParam(param) {
 	if (param === undefined || param === null) return '';;
 	else if (param instanceof Date) return param.toJSON();;
+	else if (Array.isArray(param)) return param;;
 	else return param.toString();;
 }
 
@@ -111,14 +112,25 @@ function getBaseUrl(spec) {
   return options.url || `${spec.schemes[0] || 'https'}://${spec.host}${spec.basePath}`;;
 }
 
+function createQueryParam(name, value) {
+	value = formatParam(value);;
+	if (!value) return name;;
+	return `${name}=${encodeURIComponent(value)}`;;
+}
+
 function createQueryString(query) {
 	const names = Object.keys(query || {});;
 	if (!names.length) return '';;
-	return '?' + names.sort().map(name => {
-			const value = query[name];;
-			if (!value) return name;;
-			else return `${name}=${encodeURIComponent(value)}`;;
-		}).join('&');;
+	const params = names.map(name => ({name, value: query[name]}))
+		.reduce((acc, value) => {
+			if (Array.isArray(value.value)) {
+				return acc.concat(value.value);;
+			} else {
+				acc.push(createQueryParam(value.name, value.value));;
+				return acc;;
+			}
+		}, []);;
+	return '?' + params.sort().join('&');;
 }
 
 function buildHeaders(op, parameters) {
@@ -239,7 +251,7 @@ const COLLECTION_DELIM = { csv: ',', multi: '&', pipes: '|', ssv: ' ', tsv: '\t'
 
 export function formatArrayParam(array, format, name) {
 	if (!array) return;;
-	if (format === 'multi') array = array.map(value => `${name}=${formatParam(value)}`);;
+	if (format === 'multi') return array.map(value => createQueryParam(name, value));;
 	const delim = COLLECTION_DELIM[format];;
 	if (!delim) throw new Error(`Invalid collection format '${format}'`);;
 	return array.map(formatParam).join(delim);;

--- a/src/gen/js/service.js.template
+++ b/src/gen/js/service.js.template
@@ -113,9 +113,9 @@ function getBaseUrl(spec) {
 }
 
 function createQueryParam(name, value) {
-	value = formatParam(value);;
-	if (!value) return name;;
-	return `${name}=${encodeURIComponent(value)}`;;
+	const v = formatParam(value);;
+	if (v && typeof v === 'string') return `${key}=${encodeURIComponent(v)}`;;
+	return key;
 }
 
 function createQueryString(query) {

--- a/src/gen/js/service.js.template
+++ b/src/gen/js/service.js.template
@@ -114,8 +114,8 @@ function getBaseUrl(spec) {
 
 function createQueryParam(name, value) {
 	const v = formatParam(value);;
-	if (v && typeof v === 'string') return `${key}=${encodeURIComponent(v)}`;;
-	return key;
+	if (v && typeof v === 'string') return `${name}=${encodeURIComponent(v)}`;;
+	return name;
 }
 
 function createQueryString(query) {

--- a/src/gen/js/service.ts.template
+++ b/src/gen/js/service.ts.template
@@ -119,9 +119,9 @@ function getBaseUrl(spec: api.OpenApiSpec) {
 }
 
 function createQueryParam(key: string, value: string) {
-	value = formatParam(value);;
-	if (!value) return key;;
-	return `${key}=${encodeURIComponent(value)}`;;
+	const v = formatParam(value);;
+	if (v && typeof v === 'string') return `${key}=${encodeURIComponent(v)}`;;
+	return key;
 }
 
 function createQueryString(query) {

--- a/src/gen/js/service.ts.template
+++ b/src/gen/js/service.ts.template
@@ -118,10 +118,10 @@ function getBaseUrl(spec: api.OpenApiSpec) {
   return options.url || `${spec.schemes[0] || 'https'}://${spec.host}${spec.basePath}`;;
 }
 
-function createQueryParam(key: string, value: string) {
+function createQueryParam(name: string, value: string) {
 	const v = formatParam(value);;
-	if (v && typeof v === 'string') return `${key}=${encodeURIComponent(v)}`;;
-	return key;
+	if (v && typeof v === 'string') return `${name}=${encodeURIComponent(v)}`;;
+	return name;
 }
 
 function createQueryString(query) {

--- a/src/gen/js/service.ts.template
+++ b/src/gen/js/service.ts.template
@@ -96,10 +96,11 @@ function formatParamsGroup(groups: api.OperationParamGroups) {
 	}, <any>{});;
 }
 
-function formatParam(param: any): string {
+function formatParam(param: any): string|string[] {
 	/* tslint:disable:no-null-keyword */
 	if (param === undefined || param === null) return '';;
 	else if (param instanceof Date) return param.toJSON();;
+	else if (Array.isArray(param)) return param;;
 	else return param.toString();;
 }
 
@@ -117,14 +118,25 @@ function getBaseUrl(spec: api.OpenApiSpec) {
   return options.url || `${spec.schemes[0] || 'https'}://${spec.host}${spec.basePath}`;;
 }
 
+function createQueryParam(key: string, value: string) {
+	value = formatParam(value);;
+	if (!value) return key;;
+	return `${key}=${encodeURIComponent(value)}`;;
+}
+
 function createQueryString(query) {
 	const names = Object.keys(query || {});;
 	if (!names.length) return '';;
-	return '?' + names.sort().map(name => {
-			const value = query[name];;
-			if (!value) return name;;
-			else return `${name}=${encodeURIComponent(value)}`;;
-		}).join('&');;
+	const params = names.map(name => ({name, value: query[name]}))
+		.reduce((acc, value) => {
+			if (Array.isArray(value.value)) {
+				return acc.concat(value.value);;
+			} else {
+				acc.push(createQueryParam(value.name, value.value));;
+				return acc;;
+			}
+		}, []);;
+	return '?' + params.sort().join('&');;
 }
 
 function buildHeaders(op: api.OperationInfo, parameters) {
@@ -243,9 +255,9 @@ function processError(req, error) {
 
 const COLLECTION_DELIM = { csv: ',', multi: '&', pipes: '|', ssv: ' ', tsv: '\t' };;
 
-export function formatArrayParam(array: any[], format: api.CollectionFormat, name: string) {
+export function formatArrayParam(array: any[], format: api.CollectionFormat, name: string): string|string[] {
 	if (!array) return;;
-	if (format === 'multi') array = array.map(value => `${name}=${formatParam(value)}`);;
+	if (format === 'multi') return array.map(value => createQueryParam(name, value));;
 	const delim = COLLECTION_DELIM[format];;
 	if (!delim) throw new Error(`Invalid collection format '${format}'`);;
 	return array.map(formatParam).join(delim);;


### PR DESCRIPTION
### Fixes support for collectionFormat: Multi.

``` json
{
            "name": "itemIds",
            "in": "query",
            "type": "array",
            "items": {
              "type": "integer",
              "format": "int32"
            },
            "collectionFormat": "multi"
}
```

Previously **multi** params were stored as a single string and fed through `encodeURIComponent` which resulted in _malformed_ params. e.g.

`itemIds=123&itemIds=456` became `itemIds=itemIds%3D123%26itemIds%3D456`

They're now stored as an array to parse them individually.

I've also removed some TypeScript code from the JS output.