### PR TITLE
Update isomorphic-fetch type dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Or globally to run CLI from anywhere
 
     npm install openapi-client -g
 
+### Type Dependencies
+
+If targeting TypeScript you'll also need to install the `isomorphic-fetch` typings in your project.
+
+    npm install @types/isomorphic-fetch --save-dev
+
 ## Usage
 
 ### CLI

--- a/src/gen/js/genTypes.ts
+++ b/src/gen/js/genTypes.ts
@@ -204,7 +204,7 @@ export interface FetchResponse extends FetchBody {
   status: number${ST}
   statusText: string${ST}
   ok: boolean${ST}
-  headers: IHeaders${ST}
+  headers: Headers${ST}
   type: string | FetchResponseType${ST}
   size: number${ST}
   timeout: number${ST}

--- a/src/gen/js/service.ts.template
+++ b/src/gen/js/service.ts.template
@@ -47,7 +47,7 @@ function acquireRights(op: api.OperationInfo, spec: api.OpenApiSpec, options: ap
 	return Promise.resolve({});;
 }
 
-function makeFetchRequest(req: api.ServiceRequest): Promise<IResponse> {
+function makeFetchRequest(req: api.ServiceRequest): Promise<Response> {
 	let fetchOptions = {
 		compress: true,
 		method: req.method,


### PR DESCRIPTION
Now using types for `isomorphic-fetch` from `@types` npm lib instead of `DefinitelyTyped` via `typings install`.