### PR TITLE
Issue 6: add OperationRights to request return type

### DIFF
--- a/src/gen/js/service.ts.template
+++ b/src/gen/js/service.ts.template
@@ -14,7 +14,7 @@ export function init(serviceOptions: api.ServiceOptions) {
 	options = serviceOptions;;
 }
 
-export function request<T>(op: api.OperationInfo, parameters?: api.OperationParamGroups, attempt = 1): Promise<T> {
+export function request<T>(op: api.OperationInfo, parameters?: api.OperationParamGroups, attempt = 1): Promise<T | api.OperationRights> {
 	if (!attempt) attempt = 1;
 	return acquireRights(op, spec, options)
 		.then(rights => {
@@ -250,7 +250,7 @@ function formatServiceError(response: api.FetchResponse, data, options: api.Serv
 }
 
 function processError(req, error) {
-	return Promise.resolve({ res: { raw: {}, data: error, error: true } });
+	return Promise.resolve(<api.ResponseOutcome>{ res: { raw: {}, data: error, error: true } });
 }
 
 const COLLECTION_DELIM = { csv: ',', multi: '&', pipes: '|', ssv: ' ', tsv: '\t' };;


### PR DESCRIPTION
We were having the same issue as described in [issue 6](https://github.com/mikestead/openapi-client/issues/6). Adding OperationRights to gateway's request function along with T fixed the issue.

We also had another issue with gateway's processError function's return type.
`home/phz/workspace/storefront/src/app/api/gateway/index.ts (30,30): Property 'retry' does not exist on type 'ResponseOutcome | { res: { raw: {}; data: any; error: boolean; }; }'.
  Property 'retry' does not exist on type '{ res: { raw: {}; data: any; error: boolean; }; }'.)`
This was fixed by asserting the return values type as ResponseOutcome.