### PR TITLE
Add options to meta

### DIFF
--- a/src/gen/js/genReduxActions.ts
+++ b/src/gen/js/genReduxActions.ts
@@ -58,7 +58,7 @@ ${isTs ? `export type ${actionComplete} = ${returnType}${ST}`: ''}
 
 export function ${op.id}(${paramSignature})${isTs? ': any' : ''} {
   return dispatch => {
-    dispatch({ type: ${actionStart}, meta: { info } })${ST}
+    dispatch({ type: ${actionStart}, meta: { info, options } })${ST}
     return ${op.group}.${op.id}(${params})
       .then(response => dispatch({
         type: ${actionComplete},
@@ -66,7 +66,8 @@ export function ${op.id}(${paramSignature})${isTs? ': any' : ''} {
         error: response.error,
         meta: {
           res: response.raw,
-          info
+          info,
+          options
         }
       }))${ST}
   }${ST}


### PR DESCRIPTION
In adiction to pass second parameter info to action, i think it's also good to pass the options object itself in meta.

### Why:
Many times in my reducers i need some options to store the payload of my action.
So i pass those variables in the second parameter and get them as `action.meta.info`
But most times i am already sending that option as the main options object like:
```javascript
dispatch(someAction({ userId },{ userId }))
``` 

Then in reducer i use `action.meta.info.userId` to set that user as loading on start and set the data on complete. with this PR i can just do
```javascript
dispatch(someAction({ userId }))
``` 
And in the reducer use `action.meta.options.userId`