### PR TITLE
Gen docs in js actions

### DIFF
--- a/src/gen/js/genOperations.ts
+++ b/src/gen/js/genOperations.ts
@@ -52,7 +52,7 @@ function renderOperation(spec: ApiSpec, op: ApiOperation, options: ClientOptions
   return lines
 }
 
-function renderOperationDocs(op: ApiOperation): string[] {
+export function renderOperationDocs(op: ApiOperation): string[] {
   const lines = []
   lines.push(`/**`)
   join(lines, renderDocDescription(op))

--- a/src/gen/js/genReduxActions.ts
+++ b/src/gen/js/genReduxActions.ts
@@ -1,6 +1,6 @@
 import { writeFileSync, join, groupOperationsByGroupName, camelToUppercase, getBestResponse } from '../util'
 import { DOC, SP, ST, getDocType, getTSParamType } from './support'
-import { renderParamSignature, renderOperationGroup } from './genOperations'
+import {renderParamSignature, renderOperationGroup, renderOperationDocs} from './genOperations'
 
 export default function genReduxActions(spec: ApiSpec, operations: ApiOperation[], options: ClientOptions) {
   const files = genReduxActionGroupFiles(spec, operations, options)
@@ -48,7 +48,9 @@ function renderReduxActionBlock(spec: ApiSpec, op: ApiOperation, options: Client
     if (required.length) params += ', options'
     else params = 'options'
   }
-
+  const docsArray=renderOperationDocs(op)
+  docsArray.splice(docsArray.length-2, 0, `${DOC}@param {object} [info]`)
+  const docs=docsArray.join('\n')
   const response = getBestResponse(op)
   const returnType = response ? getTSParamType(response) : 'any'
   return `
@@ -56,6 +58,7 @@ export const ${actionStart} = 's/${op.group}/${actionStart}'${ST}
 export const ${actionComplete} = 's/${op.group}/${actionComplete}'${ST}
 ${isTs ? `export type ${actionComplete} = ${returnType}${ST}`: ''}
 
+${docs}
 export function ${op.id}(${paramSignature})${isTs? ': any' : ''} {
   return dispatch => {
     dispatch({ type: ${actionStart}, meta: { info } })${ST}

--- a/src/gen/js/genTypes.ts
+++ b/src/gen/js/genTypes.ts
@@ -268,6 +268,7 @@ function renderTypeDoc(name: string, def: any): string[] {
   if (propLines.length) lines.push(`${DOC}`)
   join(lines, propLines)
   lines.push(' */')
+  lines.push(`const ${name}=null`)
   lines.push('')
   return lines
 }


### PR DESCRIPTION
Generate the same docs for redux actions as we have in plain openapi call's

Usefull for code completition of actions