### PR TITLE
Add processError hook to ServiceOptions to catch service errors

### DIFF
--- a/src/gen/js/genTypes.ts
+++ b/src/gen/js/genTypes.ts
@@ -176,6 +176,7 @@ export interface ServiceOptions {
   formatServiceError?: (response: FetchResponse, data: any) => ServiceError${ST}
   processRequest?: (op: OperationInfo, reqInfo: RequestInfo) => RequestInfo${ST}
   processResponse?: (req: api.ServiceRequest, res: Response<any>, attempt: number) => Promise<api.ResponseOutcome>${ST}
+  processError?: (req: api.ServiceRequest, res: api.ResponseOutcome) => Promise<api.ResponseOutcome>${ST}
   authorizationHeader?: string${ST}
 }
 

--- a/src/gen/js/service.js.template
+++ b/src/gen/js/service.js.template
@@ -258,7 +258,10 @@ function formatServiceError(response, data, options) {
 }
 
 function processError(req, error) {
-	return Promise.resolve({ res: { raw: {}, data: error, error: true } });
+  const { processError } = options;;
+  const res = { res: { raw: error, data: error, error: true } };;
+
+  return Promise.resolve(processError ? processError(req, res) : res);;
 }
 
 const COLLECTION_DELIM = { csv: ',', multi: '&', pipes: '|', ssv: ' ', tsv: '\t' };;

--- a/src/gen/js/service.js.template
+++ b/src/gen/js/service.js.template
@@ -258,10 +258,10 @@ function formatServiceError(response, data, options) {
 }
 
 function processError(req, error) {
-  const { processError } = options;;
-  const res = { res: { raw: error, data: error, error: true } };;
+	const { processError } = options;;
+	const res = { res: { raw: {}, data: error, error: true } };;
 
-  return Promise.resolve(processError ? processError(req, res) : res);;
+	return Promise.resolve(processError ? processError(req, res) : res);;
 }
 
 const COLLECTION_DELIM = { csv: ',', multi: '&', pipes: '|', ssv: ' ', tsv: '\t' };;

--- a/src/gen/js/service.ts.template
+++ b/src/gen/js/service.ts.template
@@ -264,10 +264,10 @@ function formatServiceError(response: api.FetchResponse, data, options: api.Serv
 }
 
 function processError(req, error) {
-    const { processError } = options;;
-    const res: api.ResponseOutcome = { res: { raw: error, data: error, error: true } };;
+	const { processError } = options;;
+	const res: api.ResponseOutcome = { res: { raw: {}, data: error, error: true } };;
 
-    return Promise.resolve(processError ? processError(req, res) : res);;
+	return Promise.resolve(processError ? processError(req, res) : res);;
 }
 
 const COLLECTION_DELIM = { csv: ',', multi: '&', pipes: '|', ssv: ' ', tsv: '\t' };;

--- a/src/gen/js/service.ts.template
+++ b/src/gen/js/service.ts.template
@@ -264,7 +264,10 @@ function formatServiceError(response: api.FetchResponse, data, options: api.Serv
 }
 
 function processError(req, error) {
-	return Promise.resolve(<api.ResponseOutcome>{ res: { raw: {}, data: error, error: true } });
+    const { processError } = options;;
+    const res: api.ResponseOutcome = { res: { raw: error, data: error, error: true } };;
+
+    return Promise.resolve(processError ? processError(req, res) : res);;
 }
 
 const COLLECTION_DELIM = { csv: ',', multi: '&', pipes: '|', ssv: ' ', tsv: '\t' };;


### PR DESCRIPTION
Currently every service error is handled per request, but we can not (pre)process these errors.

For example our application fail silently in few case which is OK on the client side, but not exampltabnle in server side rendering. With `processError` we can intercept these errors.

This extension also useful if you want to change the error format or just logging issues.