### PR TITLE
fix missing type in processError in the typescript template

### DIFF
--- a/src/gen/js/service.ts.template
+++ b/src/gen/js/service.ts.template
@@ -265,7 +265,7 @@ function formatServiceError(response: api.FetchResponse, data, options: api.Serv
 
 function processError(req, error) {
 	const { processError } = options;;
-	const res: api.ResponseOutcome = { res: { raw: {}, data: error, error: true } };;
+	const res: api.ResponseOutcome = { res: { raw: {} as api.FetchResponse, data: error, error: true } };;
 
 	return Promise.resolve(processError ? processError(req, res) : res);;
 }


### PR DESCRIPTION
Unfortunately I forget to add the type to the `raw: {}` after I replaced the `raw: error`.
I checked and this casting is working in our live project and it is solve the problem.

Another possible solution if I add a new `api.ResponseErrorOutcome` type instead of the `api.ResponseOutcome`.