### PR TITLE
Escape reserved words in parameters.

### DIFF
--- a/src/gen/js/genOperations.ts
+++ b/src/gen/js/genOperations.ts
@@ -163,7 +163,53 @@ function getParamSignature(param: ApiOperationParam, options: ClientOptions): st
 
 function getParamName(name: string): string {
   const parts = name.split(/[_-\s!@\#$%^&*\(\)]/g).filter(n => !!n)
-  return parts.reduce((name, p) => `${name}${p[0].toUpperCase()}${p.slice(1)}`)
+  const reduced = parts.reduce((name, p) => `${name}${p[0].toUpperCase()}${p.slice(1)}`)
+  return escapeReservedWords(reduced)
+}
+
+function escapeReservedWords(name: string): string {
+  let escapedName = name
+
+  const reservedWords = [
+    'break',
+    'case',
+    'catch',
+    'class',
+    'const',
+    'continue',
+    'debugger',
+    'default',
+    'delete',
+    'do',
+    'else',
+    'export',
+    'extends',
+    'finally',
+    'for',
+    'function',
+    'if',
+    'import',
+    'in',
+    'instanceof',
+    'new',
+    'return',
+    'super',
+    'switch',
+    'this',
+    'throw',
+    'try',
+    'typeof',
+    'var',
+    'void',
+    'while',
+    'with',
+    'yield'
+  ]
+
+  if (reservedWords.indexOf(name) >= 0) {
+    escapedName = name + '_'
+  }
+  return escapedName
 }
 
 function renderOperationObject(spec: ApiSpec, op: ApiOperation, options: ClientOptions): string[] {


### PR DESCRIPTION
Hello, in our API we have an endpoint `/switch`, which is a reserved word in javascript. This ends up causing an error in the generated code. This patch simply adds an underscore to the end of the generated parameter name if this happens.

List from: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Keywords