### PR TITLE
Add support for parameters at the path level.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Generate ES6 or TypeScript service integration code from an OpenAPI spec.",
   "author": {
     "name": "Mike Stead",

--- a/src/gen/js/genOperations.ts
+++ b/src/gen/js/genOperations.ts
@@ -314,7 +314,7 @@ function renderOperationInfo(spec: ApiSpec, op: ApiOperation, options: ClientOpt
 }
 
 function renderSecurityInfo(security: ApiOperationSecurity[]): string[] {
-  return security.map(sec => {
+  return security.map((sec, i) => {
     const scopes = sec.scopes
     const secLines = []
     secLines.push(`${SP.repeat(2)}{`)
@@ -322,7 +322,7 @@ function renderSecurityInfo(security: ApiOperationSecurity[]): string[] {
     if (scopes) {
       secLines.push(`${SP.repeat(3)}scopes: ['${scopes.join(`', '`)}']`)
     }
-    secLines.push(`${SP.repeat(2)}}`)
+    secLines.push(`${SP.repeat(2)}}${i + 1 < security.length ? ',': ''}`)
     return secLines
   }).reduce((a, b) => a.concat(b))
 }

--- a/src/gen/js/genTypes.ts
+++ b/src/gen/js/genTypes.ts
@@ -53,7 +53,7 @@ function renderTsType(name, def, options) {
   const lines = []
   if (def.description) {
     lines.push(`/**`)
-    lines.push(DOC + def.description.trim().replace(/\n/g, `\n$${DOC}${SP}`))
+    lines.push(DOC + def.description.trim().replace(/\n/g, `\n${DOC}${SP}`))
     lines.push(` */`)
   }
   lines.push(`export interface ${name} {`)

--- a/src/spec/operations.ts
+++ b/src/spec/operations.ts
@@ -29,6 +29,15 @@ function getPathOperation(method: HttpMethod, pathInfo, spec: ApiSpec): ApiOpera
   const op = Object.assign({ method, path: pathInfo.path, parameters: [] }, pathInfo[method])
   op.id = op.operationId
 
+  let pathParams = spec.paths[pathInfo.path].parameters
+  if (pathParams) {
+    pathParams.forEach(pathParam => {
+      if (!op.parameters.find(p => p.name === pathParam.name)) {
+        op.parameters.push(pathParam)
+      }
+    })
+  }
+
   // if there's no explicit operationId given, create one based on the method and path
   if (!op.id) {
     op.id = method + pathInfo.path


### PR DESCRIPTION
Hello, openapi allows for parameters to be defined at the `path` level, one up from the `method`. These params are then to apply to all methods. This patch adds support for that construct.