### PR TITLE
Fixed bug that parameter name gets not transformed to camelCase

### DIFF
--- a/src/gen/js/genOperations.ts
+++ b/src/gen/js/genOperations.ts
@@ -161,7 +161,7 @@ function getParamSignature(param: ApiOperationParam, options: ClientOptions): st
   return signature
 }
 
-function getParamName(name: string): string {
+export function getParamName(name: string): string {
   const parts = name.split(/[_-\s!@\#$%^&*\(\)]/g).filter(n => !!n)
   const reduced = parts.reduce((name, p) => `${name}${p[0].toUpperCase()}${p.slice(1)}`)
   return escapeReservedWords(reduced)

--- a/src/gen/js/genReduxActions.ts
+++ b/src/gen/js/genReduxActions.ts
@@ -1,6 +1,6 @@
 import { writeFileSync, join, groupOperationsByGroupName, camelToUppercase, getBestResponse } from '../util'
 import { DOC, SP, ST, getDocType, getTSParamType } from './support'
-import { renderParamSignature, renderOperationGroup } from './genOperations'
+import { renderParamSignature, renderOperationGroup, getParamName } from './genOperations'
 
 export default function genReduxActions(spec: ApiSpec, operations: ApiOperation[], options: ClientOptions) {
   const files = genReduxActionGroupFiles(spec, operations, options)
@@ -43,7 +43,7 @@ function renderReduxActionBlock(spec: ApiSpec, op: ApiOperation, options: Client
   let paramSignature = renderParamSignature(op, options, `${op.group}.`)
   paramSignature += `${paramSignature ? ', ' : ''}${infoParam}`
   const required = op.parameters.filter(param => param.required)
-  let params = required.map(param => param.name).join(', ')
+  let params = required.map(param => getParamName(param.name)).join(', ')
   if (required.length < op.parameters.length) {
     if (required.length) params += ', options'
     else params = 'options'


### PR DESCRIPTION
I found a small bug within the generated redux action code.

Our API consumes a user token via http header - we call it 'X-token'.
This is a mandatory param for our action.

The code generation will output something like this:

```javascript
export function createUser(XToken, options, info) {
  return dispatch => {
    dispatch({ type: CREATE_USER_START, meta: { info } })
    return user.createUser(X-token, options)
      .then(response => dispatch({
        type: CREATE_USER,
        payload: response.data,
        error: response.error,
        meta: {
          res: response.raw,
          info
        }
      }))
  }
}
```

The param in the exported function will be correctly transformed from 'X-token' to XToken, but within the return statement the param name gets not transformed in this way. This will obviously throw an error.