### PR TITLE
Allow security override of specific endpoints

### DIFF
--- a/src/spec/operations.ts
+++ b/src/spec/operations.ts
@@ -82,8 +82,15 @@ function getOperationResponses(op: any): ApiOperationResponse[] {
 function getOperationSecurity(op: any, spec: any): ApiOperationSecurity[] {
   let security
 
-  if (op.security && op.security.length) {
-    security = op.security
+  if (op.security) {
+    if (op.security.length) {
+      security = op.security
+    }
+    else {
+      // Allow disabling security on specific endpoints
+      // if security is an empty array
+      return
+    }
   }
   else if (spec.security && spec.security.length) {
     security = spec.security


### PR DESCRIPTION
For an endpoint specified like this:

```yaml
  /pets:
      get:
        description: Example
        security: []
```

Currently openapi-client still will add security to the endpoint, just because the array exists.

This change removes the security from the operation if an empty array is passed in. 

This is discussed a little more here: https://github.com/OAI/OpenAPI-Specification/issues/14

I think this aligns with the spec because if you load a spec into the swagger editor with an endpoint like above, it won't show a lock icon, indicating there should not be auth.

Thanks!